### PR TITLE
Add haskell implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu
 MAINTAINER Judit Acs
 RUN apt-get update
-RUN yes | apt-get install -y wget curl gcc g++ nano python perl php5 git default-jdk time software-properties-common mono-mcs
+RUN yes | apt-get install -y wget curl gcc g++ nano python perl php5 git default-jdk time software-properties-common mono-mcs ghc cabal-install
 RUN yes | apt-add-repository ppa:staticfloat/juliareleases
 RUN yes | apt-get update
 RUN yes | apt-get install julia
 RUN yes | apt-get install golang-go
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 RUN sudo apt-get install --yes nodejs
+RUN cabal update
 RUN git clone https://github.com/juditacs/wordcount.git
 RUN locale-gen en_US.UTF-8  
 ENV LANG en_US.UTF-8  

--- a/haskell/Setup.hs
+++ b/haskell/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/haskell/WordCount.cabal
+++ b/haskell/WordCount.cabal
@@ -1,0 +1,20 @@
+name:                WordCount
+version:             0.1.0.0
+-- synopsis:            
+-- description:         
+-- license:             
+--license-file:        LICENSE
+author:              Larion Garaczi
+maintainer:          l4rion@gmail.com
+-- copyright:           
+category:            Language
+build-type:          Simple
+cabal-version:       >=1.8
+
+executable WordCount
+  main-is:              WordCount.hs
+  -- other-modules:       
+  build-depends:       base ==4.6.*, containers ==0.5.*, unordered-containers ==0.2.*, text ==1.2.*
+  ghc-options:
+    -O2
+    -with-rtsopts=-H512M

--- a/haskell/WordCount.hs
+++ b/haskell/WordCount.hs
@@ -1,0 +1,16 @@
+import qualified Data.Text as T;
+import qualified Data.Text.IO as TextIO;
+import qualified Data.List as L;
+import qualified Data.HashMap.Strict as H;
+import Data.Monoid;
+
+main = TextIO.interact (T.concat . map formatOutput . countWords) where
+    formatOutput (word, count) = T.concat [word, T.singleton '\t', T.pack . show $ count, T.singleton '\n']
+
+countWords :: T.Text -> [(T.Text, Int)]
+countWords = L.sortBy (\(a, b) (c, d) -> compare d b <> compare a c) .
+             H.toList .
+             H.fromListWith (+) .
+             map (\word -> (word, 1)) .
+             filter (/=T.empty) .
+             T.split (`elem` "\n\r\t\f ")

--- a/run_commands.txt
+++ b/run_commands.txt
@@ -13,3 +13,4 @@ python/wordcount_py3.py
 php php/wordcount.php
 go/bin/wordcount
 mono csharp/WordCountList.exe
+haskell/WordCount

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,3 +19,7 @@ go install wordcount
 
 cd ../csharp
 mcs WordCountList.cs
+
+cd ../haskell
+cabal install --verbose=0
+cp dist/build/WordCount/WordCount .


### PR DESCRIPTION
I am not a Haskell pro, so probably there are a lot of things that could be optimized performance-wise but it works. :) Tests pass.

root@f5e672ec4cc3:/wordcount# cat results.txt 
bash/wordcount.sh	72.01	79.67	11568
cpp/wc_baseline	30.62	26.63	354320
cpp/wc_baseline_hash	20.64	16.93	341936
cpp/wc_hash_nosync	15.30	11.74	325916
cpp/wc_vector	8.18	7.90	242944
java -classpath java WordCount	24.49	22.26	812332
java -classpath java WordCountEntries	26.84	24.36	806672
julia julia/wordcount.jl	84.43	83.20	712616
nodejs javascript/wordcount.js	65.73	60.77	1000684
nodejs javascript/wordcount2.js	47.19	42.64	343932
perl/wordcount.pl	29.28	28.78	445264
python/wordcount_py2.py	14.59	14.17	552104
python/wordcount_py3.py	26.92	26.29	481492
php php/wordcount.php	31.89	27.89	776296
go/bin/wordcount	10.08	9.36	369580
mono csharp/WordCountList.exe	24.36	16.79	332880
haskell/WordCount	47.51	46.55	1041400