### PR TITLE
Improve performance on wordcount_vector cpp code

### DIFF
--- a/cpp/wordcount_vector.cpp
+++ b/cpp/wordcount_vector.cpp
@@ -25,8 +25,8 @@ int main() {
         ++m[s];
     }
     vector<pair<int, string>> mvec;
-    for (const auto& p: m) {
-        mvec.emplace_back(p.second, p.first);
+    for (auto& p: m) {
+        mvec.emplace_back(p.second, move(p.first));
     }
     sort(mvec.begin(), mvec.end(), F());
     for (const auto& p: mvec) {

--- a/cpp/wordcount_vector.cpp
+++ b/cpp/wordcount_vector.cpp
@@ -3,10 +3,13 @@
 #include <unordered_map>
 #include <algorithm>
 
+using namespace std;
 
 class F {
 public:
-    bool operator()(std::pair<int, std::string> const& lhs, std::pair<int, std::string> const& rhs) {
+    using value_type = pair<int, string>;
+
+    bool operator()(value_type const& lhs, value_type const& rhs) {
         if (lhs.first > rhs.first) return true;
         if (lhs.first == rhs.first && lhs.second < rhs.second) return true;
         return false;
@@ -14,18 +17,20 @@ public:
 };
 
 int main() {
-    std::unordered_map<std::string, int> m;
-    std::string s;
-    std::ios_base::sync_with_stdio(false);
-    std::cin.tie(nullptr);
-    while (std::cin >> s) {
+    unordered_map<string, int> m;
+    string s;
+    ios_base::sync_with_stdio(false);
+    cin.tie(nullptr);
+    while (cin >> s) {
         ++m[s];
     }
-    std::vector<std::pair<int, std::string>> mvec;
-    for (auto p: m) mvec.push_back(std::pair<int, std::string>{p.second, p.first});
-    std::sort(mvec.begin(), mvec.end(), F());
-    for (auto p: mvec) {
-        std::cout << p.second << "\t" << p.first << "\n";
+    vector<pair<int, string>> mvec;
+    for (const auto& p: m) {
+        mvec.emplace_back(p.second, p.first);
+    }
+    sort(mvec.begin(), mvec.end(), F());
+    for (const auto& p: mvec) {
+        cout << p.second << "\t" << p.first << "\n";
     }
 
 }


### PR DESCRIPTION
This code improves the performance of the C++ wordcount_vector code. I also pulled namespace std as it's otherwise super verbose for such a short code snippet.

Performance improvement is about 15% (I tested this against /usr/share/dict/words appended multiple times into the same file). This is just by not creating a useless copy of each element while iterating both the `unordered_map` and the `vector`. I also used `vector::emplace_back`, which might save a tiny bit of time, but this should be negligible. 