### PR TITLE
fix bash, count with hashtable in awk

### DIFF
--- a/bash/wordcount.sh
+++ b/bash/wordcount.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export LC_COLLATE=C
-sed 's/[\t ]/\n/g' | grep -v ^$ | sort | uniq -c | sed 's/^\s*//' | sort  -k1,2nr -k2 | awk 'BEGIN{OFS="\t"}{print $2,$1}'
+tr '\t ' '\n\n' | grep -v ^$ | awk '{x[$0]++} END {for (w in x) {print x[w], w}}' | sort -k1,2nr -k2 | awk 'BEGIN{OFS="\t"}{print $2,$1}'


### PR DESCRIPTION
- on OSX the initial sed was not splitting the lines correctly, switched to `tr`
- `sort | uniq -c` is handily beaten by awk for counting

could also use awk instead of `tr` for splitting, but at that point may as well add an awk submission