### PR TITLE
C# Improvements

### DIFF
--- a/csharp/WordCountList.cs
+++ b/csharp/WordCountList.cs
@@ -6,7 +6,7 @@ namespace WordCountProgram
 {
     public class Program
     {
-        public static void Main()
+        public static void Main2()
         {
             var wordCounts = new Dictionary<string, WordCount>();
             var wordCountList = new List<WordCount>();

--- a/csharp/WordCountList.cs
+++ b/csharp/WordCountList.cs
@@ -6,19 +6,19 @@ namespace WordCountProgram
 {
     public class Program
     {
-        public static void Main2()
+        public static void Main()
         {
             var wordCounts = new Dictionary<string, WordCount>();
             var wordCountList = new List<WordCount>();
             string line;
-            
+            WordCount wc = null;
             while ((line = Console.ReadLine()) != null) 
             {
                 foreach (var word in line.Split(new [] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    if (wordCounts.ContainsKey(word))
+                    if (wordCounts.TryGetValue(word, out wc))
                     {
-                        wordCounts[word].Count++;
+                        wc.Count++;
                     }
                     else
                     {

--- a/csharp/WordCount_TPoise.cs
+++ b/csharp/WordCount_TPoise.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WordCount_TPoise
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            var wordCounts = new Dictionary<string, uint>(Convert.ToInt32(Math.Pow(2.0, 16.0)));
+            string line;
+
+            while ((line = Console.ReadLine()) != null)
+            {
+                uint count = 0;
+
+                foreach (string word in line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (wordCounts.TryGetValue(word, out count))
+                        wordCounts[word] = ++count;
+                    else
+                        wordCounts[word] = 1;
+
+                }
+            }
+
+            foreach (var wordCount in wordCounts.AsParallel().OrderByDescending(k => k.Value).ThenBy(k => k.Key).Take(10))
+            {
+                Console.WriteLine("{0}\t{1}", wordCount.Key, wordCount.Value);
+            }
+
+        }
+        
+    }
+}

--- a/csharp/WordCount_TPoise.cs
+++ b/csharp/WordCount_TPoise.cs
@@ -2,35 +2,65 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace WordCount_TPoise
+namespace WordCountProgram
 {
     public class Program
     {
         public static void Main()
         {
-            var wordCounts = new Dictionary<string, uint>(Convert.ToInt32(Math.Pow(2.0, 16.0)));
+            var wordCounts = new Dictionary<string, WordCount>();
+            var wordCountList = new List<WordCount>();
             string line;
-
+            WordCount wc = null;
             while ((line = Console.ReadLine()) != null)
             {
-                uint count = 0;
-
-                foreach (string word in line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+                foreach (var word in line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    if (wordCounts.TryGetValue(word, out count))
-                        wordCounts[word] = ++count;
+                    if (wordCounts.TryGetValue(word, out wc))
+                    {
+                        wc.Count++;
+                    }
                     else
-                        wordCounts[word] = 1;
-
+                    {
+                        var initialwordCount = new WordCount(word);
+                        wordCounts[word] = initialwordCount;
+                        wordCountList.Add(initialwordCount);
+                    }
                 }
             }
 
-            foreach (var wordCount in wordCounts.AsParallel().OrderByDescending(k => k.Value).ThenBy(k => k.Key))
-            {
-                Console.WriteLine("{0}\t{1}", wordCount.Key, wordCount.Value);
-            }
+            wordCountList.Sort(new WordCountComparer());
 
+            foreach (var wordCount in wordCountList)
+            {
+                Console.WriteLine("{0}\t{1}", wordCount.Word, wordCount.Count);
+            }
         }
-        
+    }
+
+    public class WordCount
+    {
+        public WordCount(string word)
+        {
+            Word = word;
+            Count = 1;
+        }
+
+        public readonly string Word;
+
+        public long Count;
+    }
+
+    public class WordCountComparer : IComparer<WordCount>
+    {
+        public int Compare(WordCount x, WordCount y)
+        {
+            var compareTo = Comparer<long>.Default.Compare(x.Count, y.Count);
+
+            if (compareTo != 0)
+                return -compareTo;
+
+            return String.Compare(x.Word, y.Word, StringComparison.Ordinal);
+        }
     }
 }

--- a/csharp/WordCount_TPoise.cs
+++ b/csharp/WordCount_TPoise.cs
@@ -25,7 +25,7 @@ namespace WordCount_TPoise
                 }
             }
 
-            foreach (var wordCount in wordCounts.AsParallel().OrderByDescending(k => k.Value).ThenBy(k => k.Key).Take(10))
+            foreach (var wordCount in wordCounts.AsParallel().OrderByDescending(k => k.Value).ThenBy(k => k.Key))
             {
                 Console.WriteLine("{0}\t{1}", wordCount.Key, wordCount.Value);
             }

--- a/csharp/project.json
+++ b/csharp/project.json
@@ -1,19 +1,20 @@
-﻿{
+{
     "name": "WordCount",
     "version": "1.0.0-*",
     "description": "WordCount",
-    "authors": [ "Peter Szel" ],
+    "authors": [ "Peter Szel", "@TPoise" ],
     "compilationOptions": {
         "emitEntryPoint": true
     },
 
-    "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "System.IO": "4.0.11-beta-*",
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*",
-        "System.Linq": "4.0.1-beta-23516"
-    },
+  "dependencies": {
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
+    "System.IO": "4.0.11-beta-*",
+    "System.Console": "4.0.0-beta-*",
+    "System.Runtime": "4.0.21-beta-*",
+    "System.Linq": "4.0.1-beta-23516",
+    "System.Linq.Parallel": "4.0.1-beta-23516"
+  },
 
     "frameworks": {
         "dnxcore50": { }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ export GOPATH=$(pwd)
 go install wordcount
 
 cd ../csharp
-mcs WordCount_TPoise.cs
+mcs WordCountList.cs
 
 cd ../haskell
 cabal install --verbose=0


### PR DESCRIPTION
On my machine, **this is about 2x faster** than the previous version.

1.  Presizing the dictionary to prevent re-sizes
2.  Using a unsigned 32-bit integer for counting
3.  Reducing unnecessary checks on the dictionary to determine if an item is already there.
4.  Using parallel sorting 

Probably more work can be done to do a custom string splitter (http://dejan-pelzel.com/post/109194509740/c-high-performance-net-string-split).  Also using MONO is terrible.  Use the latest .NET Core (the open-source Linux-compatible version from Microsoft) at https://dotnet.github.io/getting-started/

