### PR TITLE
Added hackyish way of an ETS backed counter

### DIFF
--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -37,7 +37,3 @@ defmodule Wordcount do
     |> (fn a -> IO.write(:stdio, a) end).()
   end
 end
-
-# Improvements:
-# 1. Try to implement Hash-Based-Map/use HashDict
-# 2. Try an ETS, propably using some Hash-MStuff

--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -3,10 +3,7 @@ defmodule Wordcount do
     def new(), do: :ets.new :wc, [:set, :named_table]
 
     def count(tbl, word) do
-      case :ets.lookup(:wc, word) do
-        [{^word, cnt}] -> :ets.insert(:wc, {word, cnt + 1})
-        []             -> :ets.insert(:wc, {word, 1})
-      end
+      :ets.update_counter(tbl, word, 1, {word, 0})
       tbl
     end
 

--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -1,13 +1,34 @@
 defmodule Wordcount do
+  defmodule Store do
+    def new(), do: :ets.new :wc, [:set, :named_table]
+
+    def count(tbl, word) do
+      case :ets.lookup(:wc, word) do
+        [{^word, cnt}] -> :ets.insert(:wc, {word, cnt + 1})
+        []             -> :ets.insert(:wc, {word, 1})
+      end
+      tbl
+    end
+
+    def to_list(tbl) do
+      :ets.foldl(fn {w, _} = entry, acc ->
+        new_acc = [entry|acc]
+        :ets.delete(tbl, w)
+        new_acc
+      end, [], tbl)
+    end
+  end
+
   def main([]), do: wordcount()
 
   defp wordcount() do
     IO.stream(:stdio, :line)
     |> Stream.flat_map(&Regex.scan(~r/\S+/, &1))
-    |> Enum.reduce(%{}, fn
-      "",   cnt -> cnt
-      word, cnt -> Map.update(cnt, word, 1, &(&1 + 1))
+    |> Enum.reduce(Store.new, fn
+      word, tbl ->
+        Store.count(tbl, word)
     end)
+    |> Store.to_list
     |> Enum.sort(fn
       {word1, count},  {word2, count}  -> word1 < word2
       {_,     count1}, {_,     count2} -> count1 > count2
@@ -16,3 +37,7 @@ defmodule Wordcount do
     |> (fn a -> IO.write(:stdio, a) end).()
   end
 end
+
+# Improvements:
+# 1. Try to implement Hash-Based-Map/use HashDict
+# 2. Try an ETS, propably using some Hash-MStuff

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -6,9 +6,15 @@ defmodule Wordcount.Mixfile do
      version: "0.0.1",
      elixir: "~> 1.2",
      escript: escript,
+     erlc_options: erlc,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]
+  end
+
+  def erlc do
+    [:native,
+     {:hipe, [:o3]}]
   end
 
   def escript do


### PR DESCRIPTION
This improved runtime for the small testset (scripts/create_input.sh) by
50 secs (~120 to ~70) at the cost of some memory, which went from
~1.65GiB to ~1.87GiB.

This is mostly due to the following (assuming OTP 18; its even worse in OTP 17):

* An Elixir `Map` (denoted by `%{}` in source code) uses an erlang map under the hood, which is immutable.
  * This immutability does require copying the whole map on every single update. Even if most references can be reused the time necessary for copying grows linear with the number of entries.
  * Because of some not further explained implemention details of erlangs list even the time necessary for a lookup increases linear with the size of the map.
* To replace it, I've switched over to an Erlang-Term-Storage (known as `ets`).
  * The ETS is a global mutable state and as such discouraged usually in functional languages but fits well into erlangs and elixirs default application structure and design
  * Lookup, insertion and update don't depend on the number of entries in the table, but only on the size of the key

Normaly One would put that module I added into another source-file, but I'm not sure how to do it in a way that source-mapping stays intact.

Apropos sourcemapping. Currently I'm the only one who appears in a `git blame` but @belaustegui did some initial work and also discovered this project. I want to give him also credits. How can we have him back into the list of contributors?