### PR TITLE
Memory improvements in clojure implementation.

### DIFF
--- a/clojure/wordcount.clj
+++ b/clojure/wordcount.clj
@@ -1,13 +1,13 @@
 (require '[clojure.string :as str])
+(require '[clojure.java.io :as io])
 
 (defn -main []
-  (let [in (slurp *in*)]
-    (->> (-> (str/split in #"\s+")
-             frequencies
-             (dissoc ""))
+  (let [lines (-> *in* java.io.BufferedReader. line-seq)
+        words (mapcat #(str/split % #"\s+") lines)
+        freq (frequencies words)]
+    (->> (dissoc freq "")
          (sort-by (fn [[token freq]] [(- freq) token]))
-         (map (fn [[token freq]] (str token "\t" freq)))
-         (str/join "\n")
-         println)))
+         (map (fn [[token freq]] (println (str token "\t" freq))))
+         dorun)))
 
 (-main)


### PR DESCRIPTION
File is parsed line by line instead of all in one chunk.
Result is printed line by line instead of all in one chunk.

Running the following consumes less than 3.8G for me:
```
cat data/huwikisource-latest-pages-meta-current.xml | head -n5M | /usr/bin/time java -Xmx1500m -classpath clojure.jar clojure.main clojure/wordcount.clj > /dev/null
```