### PR TITLE
Fix sort in C++ and remove unnecessary copies

### DIFF
--- a/cpp/wordcount.cpp
+++ b/cpp/wordcount.cpp
@@ -1,28 +1,37 @@
+#include <algorithm>
 #include <iostream>
-#include <vector>
+#include <memory>
 #include <tuple>
 #include <unordered_map>
-#include <algorithm>
 
-using namespace std;
+struct word_freq {
+	std::string const* word;
+	int                freq;
+};
 
 int main() {
-    unordered_map<string, int> m;
-    m.max_load_factor(0.5);
-    string s;
-    ios_base::sync_with_stdio(false);
-    cin.tie(nullptr);
-    while (cin >> s) {
-        --m[s];
-    }
-    vector<tuple<int, string>> mvec;
-    mvec.reserve(m.size());
-    for (auto& p: m) {
-        mvec.emplace_back(p.second, move(p.first));
-    }
-    sort(mvec.begin(), mvec.end());
-    for (const auto& p: mvec) {
-        cout << get<1>(p) << "\t" << -get<0>(p) << "\n";
-    }
+	std::ios_base::sync_with_stdio(false);
+	std::cin.tie(nullptr);
 
+	std::unordered_map<std::string, int> m;
+	m.max_load_factor(0.5);
+	std::string s;
+	while (std::cin >> s) {
+		++m[s];
+	}
+
+	auto const size = m.size();
+	std::unique_ptr<word_freq[]> v(new word_freq[size]);
+	std::transform(m.begin(), m.end(), v.get(), [](auto const& p){
+		return word_freq{&p.first, p.second};
+	});
+
+	auto const v_end = v.get() + size;
+	std::sort(v.get(), v_end, [](auto const& l, auto const& r){
+		return std::tie(r.freq, *l.word) < std::tie(l.freq, *r.word);
+	});
+
+	for (auto wf = v.get(); wf != v_end; ++wf) {
+		std::cout << wf->freq << "\t" << *wf->word << "\n";
+	}
 }


### PR DESCRIPTION
Revert the sort back to descending by occurrence. 

The type of `p` on line 21 is `std::pair<const std::string, int>` so the call
to `move` on the next line will return `const std::string&` instead of an
r-value reference. This means that there is still an additional string copy
here. This commit stores pointers to the string to avoid this extra copy.

A new `struct` called `word_freq` has been created because it is a POD type
(unlike `std::pair<const std::string*, int>`). We replace the `std::vector`
with a dynamically allocated array to avoid calling the destructor of any
`word_freq` objects. Also creating the array with the correct size avoids
any reallocation and branching in `push_back`.
