### PR TITLE
[WIP] Optimize bash and python

### DIFF
--- a/bash/wordcount.sh
+++ b/bash/wordcount.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 export LC_COLLATE=C
-sed 's/[\t ]/\n/g' | grep -v ^$ | sort | uniq -c | sed 's/^\s*//' | sort  -k1,2nr -k2 | awk 'BEGIN{OFS="\t"}{print $2,$1}'
+export PHYS_CORES=$(cat /proc/cpuinfo | grep 'core id' | sort | uniq | wc -l)
+sed -E 's/[\t ]+/\n/g' | grep -v ^$ | sort -S 40% --parallel $PHYS_CORES | uniq -c | sort -S 40% ---parallel $PHYS_CORES 2 -k1,2nr -k2 | awk 'BEGIN{OFS="\t"}{print $2,$1}'

--- a/python/wordcount_py3.py
+++ b/python/wordcount_py3.py
@@ -16,7 +16,7 @@ def word_count():
 
     # Print as bytes
     for word, count in wordlist:
-        stdout.buffer.write(word + b'/t' + str(count).encode('utf-8'))
+        stdout.buffer.write(word + b'\t' + str(count).encode('utf-8')+b'\n')
 
 if __name__ == '__main__':
     word_count()

--- a/python/wordcount_py3.py
+++ b/python/wordcount_py3.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 from collections import defaultdict
 from sys import stdin
+from sys import stdout
 import codecs
-
-stdin = codecs.getreader('utf8')(stdin.detach(), errors='ignore')
 
 
 def word_count():
     counter = defaultdict(int)
-    for l in stdin:
-        for word in bytes(l, 'utf8').split():
+    for l in stdin.buffer:
+        for word in l.split():
             counter[word] += 1
-    for word, cnt in sorted(counter.items(), key=lambda x: (-x[1], x[0])):
-        print('{0}\t{1}'.format(word.decode('utf8'), cnt))
+    wordlist = [(word,count) for word,count in counter.items()]
+    del counter  # Free the memory, man!
+    wordlist.sort(key=lambda x: (-x[1], x[0]))
+
+    # Print as bytes
+    for word, count in wordlist:
+        stdout.buffer.write(word + b'/t' + str(count).encode('utf-8'))
 
 if __name__ == '__main__':
     word_count()


### PR DESCRIPTION
Replaces https://github.com/juditacs/wordcount/pull/72 since similar changes have gotten pulled into 
other PRs and I don't want merge conflicts.

Benchmark: `time cat data/huwikisource-latest-pages-meta-current.xml | mycommand > /dev/null`
System: Macbook Pro mid-2014 edition, 2.2 GHz Core i7
Times: real / CPU/ sys

Bash optimization history:
-  TODO show benchmarks

Python optimizations:

0. Baseline:  25.631s / 25.145s / 0.493s - output md5sum b52070c4fdd3b0b87ea5659e2e862128 
1. Remove UTF-8 encode/decode, and directly sort list:14.633s / 14.302s / 0.368s - output md5sum: b52070c4fdd3b0b87ea5659e2e862128
2. Partition and sort 

Baseline: 25-26s to run on 

- [ ] 