### PR TITLE
Elixir improvements, again!

### DIFF
--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -21,8 +21,9 @@ defmodule Wordcount do
   def main([]), do: wordcount()
 
   defp wordcount() do
+    pattern = :binary.compile_pattern([" "])
     IO.stream(:stdio, :line)
-    |> Stream.flat_map(&String.split(&1, [" ", "\n"]))
+    |> Stream.flat_map(&:binary.split(&1, pattern, [:global]))
     |> Stream.map(&String.strip/1)
     # |> Enum.into([]) |> IO.inspect
     |> Enum.reduce(Store.new, fn

--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -21,10 +21,10 @@ defmodule Wordcount do
   def main([]), do: wordcount()
 
   defp wordcount() do
-    pattern = :binary.compile_pattern([" "])
+    pattern = :binary.compile_pattern([" ", "\n", "\t"])
     IO.stream(:stdio, :line)
     |> Stream.flat_map(&:binary.split(&1, pattern, [:global]))
-    |> Stream.map(&String.strip/1)
+    # |> Stream.map(&:binary.replace(&1, pattern, "", [:global])) # (&String.strip/1)
     # |> Enum.into([]) |> IO.inspect
     |> Enum.reduce(Store.new, fn
       word, tbl ->

--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -2,6 +2,7 @@ defmodule Wordcount do
   defmodule Store do
     def new(), do: :ets.new :wc, [:set, :named_table]
 
+    def count(tbl, ""), do: tbl
     def count(tbl, word) do
       :ets.update_counter(tbl, word, 1, {word, 0})
       tbl
@@ -16,11 +17,14 @@ defmodule Wordcount do
     end
   end
 
+  def main(), do: main([]) # needed for profiling only
   def main([]), do: wordcount()
 
   defp wordcount() do
     IO.stream(:stdio, :line)
-    |> Stream.flat_map(&Regex.scan(~r/\S+/, &1))
+    |> Stream.flat_map(&String.split(&1, [" ", "\n"]))
+    |> Stream.map(&String.strip/1)
+    # |> Enum.into([]) |> IO.inspect
     |> Enum.reduce(Store.new, fn
       word, tbl ->
         Store.count(tbl, word)

--- a/elixir/lib/wordcount.ex
+++ b/elixir/lib/wordcount.ex
@@ -24,8 +24,6 @@ defmodule Wordcount do
     pattern = :binary.compile_pattern([" ", "\n", "\t"])
     IO.stream(:stdio, :line)
     |> Stream.flat_map(&:binary.split(&1, pattern, [:global]))
-    # |> Stream.map(&:binary.replace(&1, pattern, "", [:global])) # (&String.strip/1)
-    # |> Enum.into([]) |> IO.inspect
     |> Enum.reduce(Store.new, fn
       word, tbl ->
         Store.count(tbl, word)


### PR DESCRIPTION
I did some profiling and refactored some stuff.

I went from ~1min to ~40secs on my machine on huwikisource.

Funny facts:
* Profiling using the first 50k lines of huwiki took about 15 GiB (physical and swap) of memory while leaving my laptop in an unusable state for about 10 minutes, not even the clock was updating during this time.
* So I actually profiled with 30k lines, which did only took ~6 GiB and finished after a minute while still beeing able to use my machine.
* During the last profile run we started the garbage collector 4350 times and spent only 327ms in it! (this does not include the profilers overhead and is as such a clean value only related to counting words! This is possible because the profiler is in a seperate thread and the underlying VM has seperate GCs for each thread)