### PR TITLE
Rewrite of JS version to pass tests and work faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yes | apt-get install golang-go
 RUN yes | apt-get install lua5.2
 RUN yes | apt-get install clang-3.6
 RUN yes | apt-get install ruby2.3
-RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+RUN curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
 RUN sudo apt-get install --yes nodejs
 RUN cabal update
 RUN curl -sSf https://static.rust-lang.org/rustup.sh | sh


### PR DESCRIPTION
Two major changes in this version:
- it passes tests
- it works much faster on 5M lines

Here is a description what was changed and how it affects performance https://olg.io/blog/2016/nodejs-wordcount/  in case someone is interested in details.

It will still fail on full data set due to nodeJS heap limits (1.5Gb by default, can be increased to 4Gb with command line options, but it's not enough). There is a way to workaround limitations by using of ArrayBuffer. But it requires a lot of effort to model required data structures manually in memory chunks. Maybe I'll find time to implement a version for full data set later.