### PR TITLE
[PHP] Add output buffering

### DIFF
--- a/php/wordcount.php
+++ b/php/wordcount.php
@@ -29,9 +29,11 @@ foreach ($countedWords as $word => $count) {
 
 krsort($groupedByCountWords);
 
+ob_start(null, 4096);
 foreach ($groupedByCountWords as $count => $words) {
     sort($words, SORT_STRING);
     foreach ($words as $word) {
         printf("%s\t%s\n", $word, $count);
     }
 }
+ob_end_flush();


### PR DESCRIPTION
Output buffering significantly improves performance. I ran comparison tests on a smaller dataset and got the following results:

``$ bash scripts/compare.sh data/huwikisource-latest-pages-meta-current.xml 1``
``$ cat results.txt | python2 scripts/evaluate_results.py``

| Rank | Experiment | CPU seconds | User time | Maximum memory | Contributor |
| :---: | :---: | :---: | :---: | :---: | :---: |
| 1 | java -Xmx6G -classpath java:java/trove-3.0.3.jar WordCountOptimized | 6.17 | 9.11 | 374120 | Sam Van Oort |
| 2 | php7.0 php/wordcount.php | 6.94 | 6.43 | 261776 | Andrey Bukatov, Braun Patrik |
| 3 | rust/wordcount/wordcount | 7.35 | 6.25 | 327996 | Joshua Holmer |
| 4 | hhvm php/wordcount.php | 8.04 | 7.18 | 317664 | Andrey Bukatov, Braun Patrik |
| 5 | c/wordcount | 8.05 | 7.05 | 137872 | gaebor |
| 6 | cpp/wordcount_clang | 8.27 | 7.15 | 260908 |  |
| 7 | cpp/wordcount | 8.45 | 7.54 | 260848 | Dmitry Andreev, Matias Fontanini, Judit Acs |
| 8 | python/wordcount_py2.py | 9.85 | 9.47 | 246920 | Judit Acs |
| 9 | go/bin/wordcount | 10.97 | 9.81 | 368832 | David Siklosi |
| 10 | d/wordcount | 10.98 | 8.68 | 382768 | Pavel Chebotarev |
| 11 | java -Xmx6G -classpath java WordCountBaseline | 11.6 | 26.56 | 578544 | Sam Van Oort, Rick Hendricksen, Dávid Márk Nemeskey |
| 12 | mono csharp/WordCount.exe | 14.1 | 12.98 | 322048 | Joe Amenta, Tim Posey, Peter Szel |
| 13 | php5.6 php/wordcount.php | 16.55 | 15.68 | 788092 | Andrey Bukatov, Braun Patrik |
| 14 | python/wordcount_py2_baseline.py | 17.27 | 16.78 | 562140 | Judit Acs |
| 15 | python/wordcount_py3.py | 24.66 | 23.55 | 490076 | Judit Acs |
| 16 | cpp/wordcount_baseline | 28.97 | 24.9 | 361016 | Judit Acs |
| 17 | nodejs javascript/wordcount.js | 31.07 | 30.6 | 385324 | Laci Kundra |
| 18 | perl/wordcount.pl | 33.16 | 31.73 | 452200 | Larion Garaczi, Judit Acs |
| 19 | lua lua/wordcount.lua | 33.72 | 29.54 | 380248 | daurnimator |
| 20 | nodejs typescript/wordcount.js | 38.75 | 34.95 | 359524 | Braun Patrik |
| 21 | ruby2.3 ruby/wordcount.rb | 39.16 | 38.13 | 1651484 | Joshua Holmer |
| 22 | julia julia/wordcount.jl | 46.81 | 46.26 | 530752 | Attila Zseder, getzdan |
| 23 | haskell/WordCount | 53.2 | 52.09 | 1059768 | Larion Garaczi |
| 24 | scala -J-Xmx2g -classpath scala Wordcount | 54.24 | 188.85 | 960532 | Hans van den Bogert |
| 25 | elixir/wordcount | 56.41 | 51.0 | 1358800 | Norbert Melzer |
| 26 | bash/wordcount.sh | 66.53 | 68.1 | 10684 | Judit Acs |

All tests are successfully passed:
<img width="650" alt="screen shot 2016-04-23 at 17 05 08" src="https://cloud.githubusercontent.com/assets/4928584/14761904/ac678d16-0975-11e6-9b41-9d6a2d7887de.png">
