### PR TITLE
fixes juditacs/wordcount#86

### DIFF
--- a/typescript/wordcount.ts
+++ b/typescript/wordcount.ts
@@ -18,8 +18,11 @@ for(i = functions.length - 1; i >= 0; i--){
 
 
 const RegExp = /[ \t\n\r]+/g;
+function notEmpty(word:string):boolean{
+    return !!word;
+}
 rl.on('line', (line:string) => {
-    words = line.trim().split(RegExp);
+    words = line.split(RegExp).filter(notEmpty);
 
     for(i = words.length-1; i >=0 ; i--) {
         if (!words[i])


### PR DESCRIPTION
In js trim() removes not only space, tab, etc. but non-breaking space as well. So it failed to get the first word in a line if it starts with non-breaking space.
I removed using the trim function.